### PR TITLE
update CMakeLists.txt to allow being added as subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ install(EXPORT handy-targets
 )
 
 install(FILES
-    ${CMAKE_SOURCE_DIR}/cmake/handy-config.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/handy-config.cmake
     ${CMAKE_CURRENT_BINARY_DIR}/handy-config-version.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/handy
 )


### PR DESCRIPTION
to re-produce the failure, create a parent repository and add:

add_subdirectory("handy")
add_dependencies(your_app handy)